### PR TITLE
Fix deprecation notice about `bottle :unneeded`

### DIFF
--- a/Formula/nv.rb
+++ b/Formula/nv.rb
@@ -6,7 +6,6 @@ class Nv < Formula
   desc "Lightweight utility to load context specific environment variables"
   homepage "https://github.com/jcouture/nv"
   version "2.1.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
`bottle :unneeded` is not necessary anymore and is deprecated.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the jcoutuve/nv tap
```

✌️ 